### PR TITLE
Hide/show mainwindow instead of closing/reinstantiating

### DIFF
--- a/public/splashscreen.html
+++ b/public/splashscreen.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0" />
   <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
-  <title>Flux</title>
+  <title>Ad4min UI</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@junto-foundation/junto-elements@0.0.9/dist/main.css" />
   <script src="https://cdn.jsdelivr.net/npm/@junto-foundation/junto-elements@0.0.9"></script>
 </head>

--- a/src-tauri/src/system_tray.rs
+++ b/src-tauri/src/system_tray.rs
@@ -9,12 +9,12 @@ use std::fs;
 use directories::UserDirs;
 
 pub fn build_system_tray() -> SystemTray {
-    let show_ad4min = CustomMenuItem::new("show_ad4min".to_string(), "Show Ad4min");
+    let toggle_window = CustomMenuItem::new("toggle_window".to_string(), "Show/Hide Window");
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
     let copy_logs = CustomMenuItem::new("copy_logs".to_string(), "Copy Logs");
 
     let sys_tray_menu = SystemTrayMenu::new()
-        .add_item(show_ad4min)
+        .add_item(toggle_window)
         .add_native_item(SystemTrayMenuItem::Separator)
         .add_item(copy_logs)
         .add_native_item(SystemTrayMenuItem::Separator)
@@ -25,7 +25,7 @@ pub fn build_system_tray() -> SystemTray {
 
 pub fn handle_system_tray_event(app: &AppHandle<Wry>, event_id: String, port: u16) {
     match event_id.as_str() {
-        "show_ad4min" => {
+        "toggle_window" => {
             let ad4min_window = app.get_window("ad4min");
 
             if let Some(window) = ad4min_window {

--- a/src-tauri/src/system_tray.rs
+++ b/src-tauri/src/system_tray.rs
@@ -29,22 +29,12 @@ pub fn handle_system_tray_event(app: &AppHandle<Wry>, event_id: String, port: u1
             let ad4min_window = app.get_window("ad4min");
 
             if let Some(window) = ad4min_window {
-                window.show().unwrap();
-                window.set_focus().unwrap();
-            } else {                
-                let url = app_url(port);
-
-                println!("URL {}", url);
-
-                let new_ad4min_window = WindowBuilder::new(
-                    app,
-                    "ad4min",
-                    WindowUrl::App(url.into()),
-                );
-
-                log::info!("Creating ad4min UI {:?}", new_ad4min_window); 
-
-                new_ad4min_window.build();
+                if let Ok(true) = window.is_visible() {
+                    window.hide();
+                } else {
+                    window.show().unwrap();
+                    window.set_focus().unwrap();                
+                }
             }
         }
         "copy_logs" => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import Header from './components/Header';
 import Login from './components/Login';
 import './App.css';
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Button, Loader, Stack, TextInput } from '@mantine/core';
 import TrustAgent from './components/TrustAgent';
 import Navigation from './components/Navigation';
@@ -9,11 +9,7 @@ import { Ad4minContext } from './context/Ad4minContext';
 import { AgentContext, AgentProvider } from './context/AgentContext';
 import { buildAd4mClient } from './util';
 import { showNotification } from '@mantine/notifications';
-
-import { appWindow } from '@tauri-apps/api/window'
-appWindow.listen('tauri://close-requested', ({ event, payload }) => {
-  appWindow.hide()
-})
+import { appWindow } from '@tauri-apps/api/window';
 
 const App = () => {
   const {state: {
@@ -26,6 +22,21 @@ const App = () => {
   const [url, setURL] = useState("");
   const [urlError, setURLError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+
+  useEffect(() => {
+    let unlisten: () => void;
+
+    appWindow.listen('tauri://close-requested', ({ event, payload }) => {
+      appWindow.hide();
+    }).then((func) => {
+      unlisten = func;
+    }).catch(e => console.error(e));
+
+    return () => {
+      unlisten();
+    }
+  }, []);
 
   const onUrlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     event.preventDefault();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,11 @@ import { AgentContext, AgentProvider } from './context/AgentContext';
 import { buildAd4mClient } from './util';
 import { showNotification } from '@mantine/notifications';
 
+import { appWindow } from '@tauri-apps/api/window'
+appWindow.listen('tauri://close-requested', ({ event, payload }) => {
+  appWindow.hide()
+})
+
 const App = () => {
   const {state: {
     connected, isUnlocked, candidate, connectedLaoding, did


### PR DESCRIPTION
On macOS the window doesn't work right when closing and reopening, which should be changed anyway. This fixes macOS usage.