### PR TITLE
Use Literals and DID in profile

### DIFF
--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -59,7 +59,7 @@ const Profile = (props: Props) => {
     }
 
     for (const { data: {source, predicate, target} } of agent.perspective?.links!) {
-      if (source === SOURCE_PROFILE) {
+      if (source === agent.did) {
         if (predicate === PREDICATE_FIRSTNAME) {
           tempProfile.firstName = Literal.fromUrl(target).get()
         } else if (predicate === PREDICATE_LASTNAME) {

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Button, Card, Container, Group, List, Modal, Space, Text, ThemeIcon, Title } from '@mantine/core';
-import { Agent } from '@perspect3vism/ad4m';
+import { Agent, Literal } from '@perspect3vism/ad4m';
 import { useContext, useEffect, useState } from 'react';
 import { CircleCheck } from 'tabler-icons-react';
 import { PREDICATE_FIRSTNAME, PREDICATE_LASTNAME, PREDICATE_USERNAME, SOURCE_PROFILE } from '../constants/triples';
@@ -61,11 +61,11 @@ const Profile = (props: Props) => {
     for (const { data: {source, predicate, target} } of agent.perspective?.links!) {
       if (source === SOURCE_PROFILE) {
         if (predicate === PREDICATE_FIRSTNAME) {
-          tempProfile.firstName = target
+          tempProfile.firstName = Literal.fromUrl(target).get()
         } else if (predicate === PREDICATE_LASTNAME) {
-          tempProfile.lastName = target;
+          tempProfile.lastName = Literal.fromUrl(target).get();
         } else if (predicate === PREDICATE_USERNAME) {
-          tempProfile.username = target;
+          tempProfile.username = Literal.fromUrl(target).get();
         }
       }
     }

--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -61,7 +61,7 @@ export function AgentProvider({ children }: any) {
     const link = await client!.perspective.addLink(
       agentPerspective.uuid,
       new Link({
-        source: SOURCE_PROFILE,
+        source: agentStatus.did!,
         target: Literal.from(username).toUrl(),
         predicate: PREDICATE_USERNAME
       })
@@ -74,7 +74,7 @@ export function AgentProvider({ children }: any) {
       const link = await client!.perspective.addLink(
         agentPerspective.uuid,
         new Link({
-          source: SOURCE_PROFILE,
+          source: agentStatus.did!,
           target: Literal.from(firstName).toUrl(),
           predicate: PREDICATE_FIRSTNAME
         })
@@ -87,7 +87,7 @@ export function AgentProvider({ children }: any) {
       const link = await client!.perspective.addLink(
         agentPerspective.uuid,
         new Link({
-          source: SOURCE_PROFILE,
+          source: agentStatus.did!,
           target: Literal.from(lastName).toUrl(),
           predicate: PREDICATE_LASTNAME
         })

--- a/src/context/AgentContext.tsx
+++ b/src/context/AgentContext.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@perspect3vism/ad4m";
+import { Link, Literal } from "@perspect3vism/ad4m";
 import { createContext, useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { SOURCE_PROFILE, PREDICATE_FIRSTNAME, PREDICATE_LASTNAME, PREDICATE_USERNAME } from "../constants/triples";
@@ -62,7 +62,7 @@ export function AgentProvider({ children }: any) {
       agentPerspective.uuid,
       new Link({
         source: SOURCE_PROFILE,
-        target: username,
+        target: Literal.from(username).toUrl(),
         predicate: PREDICATE_USERNAME
       })
     );
@@ -75,7 +75,7 @@ export function AgentProvider({ children }: any) {
         agentPerspective.uuid,
         new Link({
           source: SOURCE_PROFILE,
-          target: firstName,
+          target: Literal.from(firstName).toUrl(),
           predicate: PREDICATE_FIRSTNAME
         })
       );
@@ -88,7 +88,7 @@ export function AgentProvider({ children }: any) {
         agentPerspective.uuid,
         new Link({
           source: SOURCE_PROFILE,
-          target: lastName,
+          target: Literal.from(lastName).toUrl(),
           predicate: PREDICATE_LASTNAME
         })
       );


### PR DESCRIPTION
Ad4m URIs should be parsable URIs. Although this is currently not enforced, it will be soon.

In order to store simple values (strings, numbers, JSON) directly within the URI, there is a AD4M-built-in `Literal` language with a TS class in the ad4m npm package, which basically just encodes and decodes JS values into and from a URL: https://github.com/perspect3vism/ad4m/blob/main/src/Literal.test.ts

Also, it is semantically much more expressive to use the users DID as source when talking about it.

This aligns ad4min's usage of the agent public perspective as profile to how Perspect3ve was doing it already.