### PR TITLE
Added way to clear state

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "open 2.1.3",
  "opener",
  "portpicker",
+ "remove_dir_all 0.7.0",
  "serde",
  "serde_json",
  "sysinfo",
@@ -2654,6 +2655,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
+dependencies = [
+ "libc",
+ "log",
+ "num_cpus",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,7 +3477,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all",
+ "remove_dir_all 0.5.3",
  "winapi",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ uuid = { version = "0.8", features = ["v4"] }
 localtunnel = "0.0.6"
 tokio = { version = "1.19.2", features = ["full"] }
 tauri-plugin-positioner = { version = "1.0", features = ["system-tray"] }
+remove_dir_all = "0.7.0"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,4 +1,8 @@
-use crate::get_main_window;
+extern crate remove_dir_all;
+use remove_dir_all::*;
+
+use crate::{get_main_window, config::{data_path, binary_path}, util::find_and_kill_processes};
+
 
 #[tauri::command]
 pub fn close_application(app_handle: tauri::AppHandle) {
@@ -10,5 +14,18 @@ pub fn close_main_window(app_handle: tauri::AppHandle) {
   let window = get_main_window(&app_handle);
   if let Ok(true) = window.is_visible() {
     let _ = window.hide();
+  }
 }
+
+#[tauri::command]
+pub fn clear_state(app_handle: tauri::AppHandle) {
+  find_and_kill_processes("ad4m");
+
+  find_and_kill_processes("holochain");
+
+  find_and_kill_processes("lair-keystore");
+  
+  remove_dir_all(data_path());
+
+  app_handle.restart();
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -15,7 +15,11 @@ pub fn binary_path() -> PathBuf {
 }
 
 pub fn holochain_binary_path() -> PathBuf {
-    binary_path().join("holochain")
+    if cfg!(windows) {
+        binary_path().join("holochain.exe")
+    } else {
+        binary_path().join("holochain")
+    }
 }
 
 #[cfg(feature = "custom-protocol")]

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -153,7 +153,7 @@ function Settings(props: Props) {
           </ActionIcon>
         </Group>
         <Button style={{ width: '160px' }} onClick={() => setLockAgentModalOpen(true)}>Lock Agent</Button>
-        <Button style={{ width: '160px' }} onClick={() => setClearAgentModalOpen(true)}>Clear Agent</Button>
+        <Button style={{ width: '160px' }} onClick={() => setClearAgentModalOpen(true)}>Delete Agent</Button>
         <Button style={{ width: '160px' }} onClick={() => invoke("close_application")}>Poweroff AD4Min</Button>
         {showProxy()}
       </Stack>
@@ -202,7 +202,7 @@ function Settings(props: Props) {
         />
         <Space h={20} />
         <Button onClick={() => clearAgent(password)} loading={loading}>
-          Lock agent
+          Delete Agent
         </Button>
       </Modal>
       <Modal


### PR DESCRIPTION
On windows deleting the root .ad4m dir doesn't work correctly because of how resources are managed so had to do a work around of killing the process first and then on the restart check if agent.json is present and delete the directory before starting ad4m.